### PR TITLE
Bug 1515547 - rename webhook -> websock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 #wsmux
 wsmux/test_log
-webhooktunnel
+websocktunnel
 main
 certs/
-cmd/whclient/whclient
+cmd/client/client

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -18,14 +18,14 @@ tasks:
           - >-
             mkdir -p /go/src/github.com/taskcluster &&
             cd /go/src/github.com/taskcluster &&
-            git clone ${event.pull_request.head.repo.git_url} webhooktunnel &&
-            cd webhooktunnel &&
+            git clone ${event.pull_request.head.repo.git_url} websocktunnel &&
+            cd websocktunnel &&
             git config advice.detachedHead false &&
             git checkout ${event.pull_request.head.sha} &&
             go test -v -race ./...
       metadata:
-        name: webhooktunnel-tests
-        description: runs tests for webhooktunnel components
+        name: websocktunnel-tests
+        description: runs tests for websocktunnel components
         owner: ${event.pull_request.user.login}@users.noreply.github.com
         source: ${event.repository.url}
 
@@ -46,14 +46,14 @@ tasks:
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh &&
             mkdir -p /go/src/github.com/taskcluster &&
             cd /go/src/github.com/taskcluster &&
-            git clone ${event.pull_request.head.repo.git_url} webhooktunnel &&
-            cd webhooktunnel &&
+            git clone ${event.pull_request.head.repo.git_url} websocktunnel &&
+            cd websocktunnel &&
             git config advice.detachedHead false &&
             git checkout ${event.pull_request.head.sha} &&
             dep check
       metadata:
-        name: webhooktunnel-dep
-        description: check dep for webhooktunnel
+        name: websocktunnel-dep
+        description: check dep for websocktunnel
         owner: ${event.pull_request.user.login}@users.noreply.github.com
         source: ${event.repository.url}
 
@@ -74,14 +74,14 @@ tasks:
             curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.12.3 &&
             mkdir -p /go/src/github.com/taskcluster &&
             cd /go/src/github.com/taskcluster &&
-            git clone ${event.pull_request.head.repo.git_url} webhooktunnel &&
-            cd webhooktunnel &&
+            git clone ${event.pull_request.head.repo.git_url} websocktunnel &&
+            cd websocktunnel &&
             git config advice.detachedHead false &&
             git checkout ${event.pull_request.head.sha} &&
             golangci-lint run
       metadata:
-        name: webhooktunnel-lint
-        description: check lint for webhooktunnel
+        name: websocktunnel-lint
+        description: check lint for websocktunnel
         owner: ${event.pull_request.user.login}@users.noreply.github.com
         source: ${event.repository.url}
 
@@ -103,15 +103,15 @@ tasks:
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh &&
             mkdir -p /go/src/github.com/taskcluster &&
             cd /go/src/github.com/taskcluster &&
-            git clone ${event.repository.url} webhooktunnel &&
-            cd webhooktunnel &&
+            git clone ${event.repository.url} websocktunnel &&
+            cd websocktunnel &&
             git config advice.detachedHead false &&
             git checkout ${event.after} &&
             dep check &&
             golangci-lint run &&
             go test -v -race ./...
       metadata:
-        name: webhooktunnel-everything
-        description: all checks for webhooktunnel
+        name: websocktunnel-everything
+        description: all checks for websocktunnel
         owner: ${event.pusher.name}@users.noreply.github.com
         source: ${event.repository.url}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM golang
 
 RUN mkdir -p /go/src/github.com/
 WORKDIR /go/src/github.com/taskcluster/
-# clone and run webhooktunnel
-RUN git clone http://github.com/taskcluster/webhooktunnel
-WORKDIR /go/src/github.com/taskcluster/webhooktunnel
+# clone and run websocktunnel
+RUN git clone http://github.com/taskcluster/websocktunnel
+WORKDIR /go/src/github.com/taskcluster/websocktunnel
 
 # set envs 
 ENV HOSTNAME=tcproxy.dev

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# webhooktunnel
-[![Task Status](https://github.taskcluster.net/v1/repository/taskcluster/webhooktunnel/master/badge.svg)](https://github.taskcluster.net/v1/repository/taskcluster/webhooktunnel/master/latest)
+# websocktunnel
+[![Task Status](https://github.taskcluster.net/v1/repository/taskcluster/websocktunnel/master/badge.svg)](https://github.taskcluster.net/v1/repository/taskcluster/webhooktunnel/master/latest)
 
-Webhooktunnel is a service that allows its clients to publicly expose specific HTTP services without publicly exposing the entire host.
-"Clients" connect to the webhooktunnel service with a specific ID, authenticating with a signed JWT, and upgrade the connection to a websocket.
+Websocketunnel is a service that allows its clients to publicly expose specific HTTP services without publicly exposing the entire host.
+"Clients" connect to the websocktunnel service with a specific ID, authenticating with a signed JWT, and upgrade the connection to a websocket.
 "Viewers" then connect to the service using a path containing that ID.
 The viewer's connection is then proxied to the client via its websocket.
-The critical characteristic is that all connections are made *to* the webhooktunnel service, so the clients need not be publicly addressible.
+The critical characteristic is that all connections are made *to* the websocktunnel service, so the clients need not be publicly addressible.
 
 # Configuration
 
@@ -37,10 +37,10 @@ In single-hosted mode, the id is included in the URL path, as shown below.
 To establish a new client connection, make a GET request to the service's hostname with path `/` and the usual websocket upgrade headers, as well as:
 
  * `Authorization` containing `Bearer <jwt>`; see below
- * `x-webhooktunnel-id` containing the client ID
+ * `x-websocktunnel-id` containing the client ID
 
 The connection will be upgraded to a websocket connection.
-The response will contain the header `x-webhooktunnel-client-url` giving the URL viewers can use to reach this client.
+The response will contain the header `x-websocktunnel-client-url` giving the URL viewers can use to reach this client.
 Clients can pass this URL, or URLs derived from it, to viewers.
 Although clients should not make assumptions about the form of this URL, at present it will either look like `https://<id>.<hostname>` (for domain-hosted mode) or `https://<hostname>/<id>` (for single-hosted mode).
 
@@ -53,8 +53,9 @@ Its `tid` claim must match the client ID exactly.
 
 ### Multiplexed Websockets
 
-The protocol used within the websocket connection between a client and the webhooktunnel service is beyond the scope of this document.
-It is implemented by the `github.com/taskcluster/webhooktunnel/wsmux` package, and the expectation is that clients will use this package directly.
+The protocol used within the websocket connection between a client and the websocktunnel service is beyond the scope of this document.
+It is implemented by the `github.com/taskcluster/websocktunnel/wsmux` package.
+The `github.com/taskcluster/websocktunnel/client` package uses this to implement the client side of the connection.
 
 ## Viewer Connections
 
@@ -70,15 +71,15 @@ That is entirely up to the client.
 
 # CLI
 
-The `whclient` command implements a client that will connect to a webhooktunnel service and proxy all connections to a specific local port.
+The `wst-client` command implements a client that will connect to a websocktunnel service and proxy all connections to a specific local port.
 It takes Taskcluster credentials and uses them to generate JWTs using the Auth service.
 
 # Development
 
 This service is tested only with go1.10.
 
-To hack on this service, install it into your GOPATH with `go get -u github.com/taskcluster/webhooktunnel`.
-Run the tests with the usual `go test` invocation (for example, `go test github.com/taskcluster/webhooktunnel`).
+To hack on this service, install it into your GOPATH with `go get -u github.com/taskcluster/websocktunnel`.
+Run the tests with the usual `go test` invocation (for example, `go test github.com/taskcluster/websocktunnel`).
 
 ## Linting
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,11 +1,11 @@
-# whclient
+# client
 --
-    import "github.com/taskcluster/webhooktunnel/whclient"
+    import "github.com/taskcluster/websocktunnel/client"
 
-Package whclient wraps a wsmux client session in a net.Listener interface. It
+Package client wraps a wsmux client session in a net.Listener interface. It
 attempts to reconnect to the proxy in case of a connection failure. It can be
 configured by setting the appropriate parameters in the Config object passed to
-whclient.New().
+client.New().
 
 ## Usage
 

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-package whclient
+package client
 
 import (
 	"net"
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
-	"github.com/taskcluster/webhooktunnel/wsmux"
+	"github.com/taskcluster/websocktunnel/util"
+	"github.com/taskcluster/websocktunnel/wsmux"
 )
 
 type clientState int
@@ -148,7 +148,7 @@ func (c *Client) connectWithRetry() (*websocket.Conn, string, error) {
 	// initial connection
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+c.token)
-	header.Set("x-webhooktunnel-id", c.id)
+	header.Set("x-websocktunnel-id", c.id)
 	// initial attempt
 	c.logger.Printf("trying to connect to %s", c.proxyAddr)
 	conn, res, err := websocket.DefaultDialer.Dial(c.proxyAddr, header)
@@ -165,7 +165,7 @@ func (c *Client) connectWithRetry() (*websocket.Conn, string, error) {
 	}
 	c.logger.Printf("connected to %s ", c.proxyAddr)
 
-	url := res.Header.Get("x-webhooktunnel-client-url")
+	url := res.Header.Get("x-websocktunnel-client-url")
 	return conn, url, err
 }
 
@@ -176,7 +176,7 @@ func (c *Client) retryConn() (*websocket.Conn, string, error) {
 
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+c.token)
-	header.Set("x-webhooktunnel-id", c.id)
+	header.Set("x-websocktunnel-id", c.id)
 
 	currentDelay := c.retry.InitialDelay
 	maxTimer := time.After(c.retry.MaxElapsedTime)
@@ -190,7 +190,7 @@ func (c *Client) retryConn() (*websocket.Conn, string, error) {
 			c.logger.Printf("trying to connect to %s", c.proxyAddr)
 			conn, res, err := websocket.DefaultDialer.Dial(c.proxyAddr, header)
 			if err == nil {
-				url := res.Header.Get("x-webhooktunnel-client-url")
+				url := res.Header.Get("x-websocktunnel-client-url")
 				return conn, url, nil
 			}
 			if !shouldRetry(res) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,4 +1,4 @@
-package whclient
+package client
 
 import (
 	"errors"
@@ -13,7 +13,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 func testConfigurer(id, addr string, retryConfig RetryConfig, logger *log.Logger) Configurer {

--- a/client/doc.go
+++ b/client/doc.go
@@ -1,5 +1,5 @@
-// Package whclient wraps a wsmux client session in a net.Listener interface.
+// Package client wraps a wsmux client session in a net.Listener interface.
 // It attempts to reconnect to the proxy in case of a connection failure.
 // It can be configured by setting the appropriate parameters in the Config object
-// passed to whclient.New().
-package whclient
+// passed to client.New().
+package client

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,4 +1,4 @@
-package whclient
+package client
 
 // clientError implements net.Error
 type clientError struct {

--- a/client/retry_config.go
+++ b/client/retry_config.go
@@ -1,4 +1,4 @@
-package whclient
+package client
 
 import (
 	"math/rand"

--- a/cmd/wst-client/main.go
+++ b/cmd/wst-client/main.go
@@ -15,18 +15,18 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/tcauth"
-	"github.com/taskcluster/webhooktunnel/whclient"
+	"github.com/taskcluster/websocktunnel/client"
 )
 
-const usage = `Webhooktunnel Client
-Webhooktunnel Client is a command line utility which establishes a connection
-to the webhooktunnel proxy and allows serving http without exposing ports to 
+const usage = `Websocketunnel Client
+Websocketunnel Client is a command line utility which establishes a connection
+to the websocktunnel proxy and allows serving http without exposing ports to 
 the internet.
 
 [Firewall/NAT [User] <--]---> [Proxy] <--- [Web]
 
-Usage: whclient <clientID> <accessToken> <targetPort> [--cert=<cert>] [--out-file=<outFile>] [--json]
-whclient -h | --help
+Usage: wst-client <clientID> <accessToken> <targetPort> [--cert=<cert>] [--out-file=<outFile>] [--json]
+client -h | --help
 
 Options:
 -h --help 		Show help
@@ -71,7 +71,7 @@ func main() {
 	// accept new streams from this channel
 	strChan := make(chan net.Conn, 1)
 
-	client, err := whclient.New(makeConfigurer(clientID, accessToken, cert))
+	client, err := client.New(makeConfigurer(clientID, accessToken, cert))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -199,8 +199,8 @@ func (f *forwarder) kill() {
 	}
 }
 
-func makeConfigurer(clientID, accessToken, certificate string) func() (whclient.Config, error) {
-	configurer := func() (whclient.Config, error) {
+func makeConfigurer(clientID, accessToken, certificate string) func() (client.Config, error) {
+	configurer := func() (client.Config, error) {
 		creds := &tcclient.Credentials{
 			ClientID:    clientID,
 			AccessToken: accessToken,
@@ -209,9 +209,9 @@ func makeConfigurer(clientID, accessToken, certificate string) func() (whclient.
 		myAuth := tcauth.New(creds)
 		whtResponse, err := myAuth.WebhooktunnelToken()
 		if err != nil {
-			return whclient.Config{}, err
+			return client.Config{}, err
 		}
-		return whclient.Config{
+		return client.Config{
 			ID:        whtResponse.TunnelID,
 			Token:     whtResponse.Token,
 			ProxyAddr: whtResponse.ProxyURL,

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	mozlog "github.com/mozilla-services/go-mozlogrus"
-	"github.com/taskcluster/webhooktunnel/whproxy"
+	"github.com/taskcluster/websocktunnel/wsproxy"
 )
 
 // starts proxy on a random port on the system
@@ -87,7 +87,7 @@ func main() {
 	}
 
 	// will panic if secrets are not loaded
-	proxy, _ := whproxy.New(whproxy.Config{
+	proxy, _ := wsproxy.New(wsproxy.Config{
 		Logger:       logger,
 		Upgrader:     upgrader,
 		JWTSecretA:   []byte(signingSecretA),

--- a/wsmux/bench_test.go
+++ b/wsmux/bench_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 // utils

--- a/wsmux/circ_buffer.go
+++ b/wsmux/circ_buffer.go
@@ -1,7 +1,7 @@
 package wsmux
 
 import (
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 type buffer struct {

--- a/wsmux/http_test.go
+++ b/wsmux/http_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 type wrapStream struct {

--- a/wsmux/mux.go
+++ b/wsmux/mux.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 // Config contains configuration for a new session, as created with `Server` or `Client`.

--- a/wsmux/session.go
+++ b/wsmux/session.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 const (

--- a/wsmux/session_test.go
+++ b/wsmux/session_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 func TestEcho(t *testing.T) {

--- a/wsmux/stream.go
+++ b/wsmux/stream.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 const (

--- a/wsmux/stream_test.go
+++ b/wsmux/stream_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/taskcluster/webhooktunnel/util"
+	"github.com/taskcluster/websocktunnel/util"
 )
 
 func TestManyStreamEchoLarge(t *testing.T) {

--- a/wsproxy/README.md
+++ b/wsproxy/README.md
@@ -1,8 +1,8 @@
-# whproxy
+# wsproxy
 --
-    import "github.com/taskcluster/webhooktunnel/whproxy"
+    import "github.com/taskcluster/websocktunnel/wsproxy"
 
-Package whproxy is a Layer-7 proxy implementation which uses WebSockets to
+Package wsproxy is a Layer-7 proxy implementation which uses WebSockets to
 communicate with clients. Incoming http and websocket requests are multiplexed
 as separate streams over a WS connection. It uses JWT for auth.
 

--- a/wsproxy/doc.go
+++ b/wsproxy/doc.go
@@ -1,4 +1,4 @@
-// Package whproxy is a Layer-7 proxy implementation which uses WebSockets to
+// Package wsproxy is a Layer-7 proxy implementation which uses WebSockets to
 // communicate with clients. Incoming http and websocket requests are
 // multiplexed as separate streams over a WS connection. It uses JWT
 // for auth.
@@ -6,4 +6,4 @@
 // browser ----> [ proxy ] <--- websocket --- client
 //
 // proxy serves endpoints exposed by client to browsers.
-package whproxy
+package wsproxy

--- a/wsproxy/errors.go
+++ b/wsproxy/errors.go
@@ -1,4 +1,4 @@
-package whproxy
+package wsproxy
 
 import (
 	"errors"

--- a/wsproxy/proxy_test.go
+++ b/wsproxy/proxy_test.go
@@ -1,4 +1,4 @@
-package whproxy
+package wsproxy
 
 import (
 	"bytes"
@@ -17,9 +17,9 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
-	"github.com/taskcluster/webhooktunnel/util"
-	"github.com/taskcluster/webhooktunnel/whclient"
-	"github.com/taskcluster/webhooktunnel/wsmux"
+	"github.com/taskcluster/websocktunnel/util"
+	"github.com/taskcluster/websocktunnel/client"
+	"github.com/taskcluster/websocktunnel/wsmux"
 )
 
 var upgrader = websocket.Upgrader{
@@ -82,7 +82,7 @@ func TestProxyRegister(t *testing.T) {
 	// set auth header dial connection to proxy
 	header := make(http.Header)
 	header.Set("Authorization ", "Bearer "+workeridjwt)
-	header.Set("x-webhooktunnel-id", workerid)
+	header.Set("x-websocktunnel-id", workerid)
 	conn1, _, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -122,7 +122,7 @@ func TestProxyRequest(t *testing.T) {
 
 	header := make(http.Header)
 	header.Set("Authorization ", "Bearer "+workeridjwt)
-	header.Set("x-webhooktunnel-id", "workerid")
+	header.Set("x-websocktunnel-id", "workerid")
 	clientWs, _, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -219,7 +219,7 @@ func TestProxyURIRewrite(t *testing.T) {
 
 	header := make(http.Header)
 	header.Set("Authorization ", "Bearer "+workeridjwt)
-	header.Set("x-webhooktunnel-id", "workerid")
+	header.Set("x-websocktunnel-id", "workerid")
 	clientWs, _, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -297,7 +297,7 @@ func TestProxyWebsocket(t *testing.T) {
 	// register worker and serve http
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+wsworkerjwt)
-	header.Set("x-webhooktunnel-id", "wsworker")
+	header.Set("x-websocktunnel-id", "wsworker")
 	clientWs, _, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -412,7 +412,7 @@ func TestWebsocketProxyControl(t *testing.T) {
 	// register worker and serve http
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+wsworkerjwt)
-	header.Set("x-webhooktunnel-id", "wsworker")
+	header.Set("x-websocktunnel-id", "wsworker")
 	clientWs, _, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -537,7 +537,7 @@ func TestWebSocketClosure(t *testing.T) {
 	// register worker and serve http
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+wsworkerjwt)
-	header.Set("x-webhooktunnel-id", "wsworker")
+	header.Set("x-websocktunnel-id", "wsworker")
 	clientWs, res, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -612,7 +612,7 @@ func TestProxySessionRemoved(t *testing.T) {
 	wsURL := util.MakeWsURL(server.URL)
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+wsworkerjwt)
-	header.Set("x-webhooktunnel-id", "wsworker")
+	header.Set("x-websocktunnel-id", "wsworker")
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -649,7 +649,7 @@ func TestProxyAuth(t *testing.T) {
 	wsURL := util.MakeWsURL(server.URL)
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+wsworkerjwt)
-	header.Set("x-webhooktunnel-id", "workerid")
+	header.Set("x-websocktunnel-id", "workerid")
 
 	conn, res, _ := websocket.DefaultDialer.Dial(wsURL, header)
 	if res == nil || res.StatusCode != 401 {
@@ -657,7 +657,7 @@ func TestProxyAuth(t *testing.T) {
 		t.Fatalf("connection should fail")
 	}
 
-	header.Set("x-webhooktunnel-id", "wsworker")
+	header.Set("x-websocktunnel-id", "wsworker")
 	conn, _, err = websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -681,7 +681,7 @@ func TestConcurrentConnections(t *testing.T) {
 	wsURL := util.MakeWsURL(server.URL)
 
 	clientLogger := genLogger()
-	client, err := whclient.New(testConfigurer("test-worker", wsURL, whclient.RetryConfig{}, clientLogger))
+	client, err := client.New(testConfigurer("test-worker", wsURL, client.RetryConfig{}, clientLogger))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -749,7 +749,7 @@ func TestProxySecrets(t *testing.T) {
 	header := make(http.Header)
 	jwt := tokenGenerator("test-worker", []byte("test-secret"))
 	header.Set("Authorization", "Bearer "+jwt)
-	header.Set("x-webhooktunnel-id", "test-worker")
+	header.Set("x-websocktunnel-id", "test-worker")
 
 	_, _, err = websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
@@ -758,7 +758,7 @@ func TestProxySecrets(t *testing.T) {
 
 	jwt = tokenGenerator("test-worker-2", []byte("another-secret"))
 	header.Set("Authorization", "Bearer "+jwt)
-	header.Set("x-webhooktunnel-id", "test-worker-2")
+	header.Set("x-websocktunnel-id", "test-worker-2")
 
 	_, _, err = websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {
@@ -767,7 +767,7 @@ func TestProxySecrets(t *testing.T) {
 }
 
 // function for generating configurer objects
-func testConfigurer(id, addr string, retryConfig whclient.RetryConfig, logger *log.Logger) whclient.Configurer {
+func testConfigurer(id, addr string, retryConfig client.RetryConfig, logger *log.Logger) client.Configurer {
 	now := time.Now()
 	expires := now.Add(30 * 24 * time.Hour)
 
@@ -780,8 +780,8 @@ func testConfigurer(id, addr string, retryConfig whclient.RetryConfig, logger *l
 
 	tokString, _ := token.SignedString([]byte("test-secret"))
 
-	return func() (whclient.Config, error) {
-		conf := whclient.Config{
+	return func() (client.Config, error) {
+		conf := client.Config{
 			ID:        id,
 			ProxyAddr: addr,
 			Token:     tokString,
@@ -816,7 +816,7 @@ func TestResponseStream(t *testing.T) {
 	wsURL := util.MakeWsURL(server.URL)
 
 	// create client
-	client, err := whclient.New(testConfigurer("test-worker", wsURL, whclient.RetryConfig{}, clientLogger))
+	client, err := client.New(testConfigurer("test-worker", wsURL, client.RetryConfig{}, clientLogger))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -899,7 +899,7 @@ func TestWebSocketStreamClient(t *testing.T) {
 	defer server.Close()
 	wsURL := util.MakeWsURL(server.URL)
 
-	client, err := whclient.New(testConfigurer("test-worker", wsURL, whclient.RetryConfig{}, genLogger()))
+	client, err := client.New(testConfigurer("test-worker", wsURL, client.RetryConfig{}, genLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -980,7 +980,7 @@ func TestDomainResolve(t *testing.T) {
 	defer server.Close()
 
 	// make connection
-	client, err := whclient.New(testConfigurer("workerid", "ws://tcproxy.dev:"+getPort(server.URL), whclient.RetryConfig{},
+	client, err := client.New(testConfigurer("workerid", "ws://tcproxy.dev:"+getPort(server.URL), client.RetryConfig{},
 		genLogger()))
 
 	if err != nil {
@@ -1071,7 +1071,7 @@ func TestProxySendsURL(t *testing.T) {
 	defer server.Close()
 
 	// make connection
-	client, err := whclient.New(testConfigurer("workerid", "ws://tcproxy.dev:"+getPort(server.URL), whclient.RetryConfig{},
+	client, err := client.New(testConfigurer("workerid", "ws://tcproxy.dev:"+getPort(server.URL), client.RetryConfig{},
 		genLogger()))
 
 	if err != nil {
@@ -1103,14 +1103,14 @@ func TestProxyDomainRegister(t *testing.T) {
 	defer server.Close()
 
 	// make connection
-	configurer := func() (whclient.Config, error) {
-		return whclient.Config{
+	configurer := func() (client.Config, error) {
+		return client.Config{
 			ID:        "workerid",
 			Token:     workeridjwt,
 			ProxyAddr: "ws://register.tcproxy.dev:" + getPort(server.URL),
 		}, nil
 	}
-	client, err := whclient.New(configurer)
+	client, err := client.New(configurer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1137,15 +1137,15 @@ func TestProxyWebSocketPath(t *testing.T) {
 	server := httptest.NewServer(proxy)
 	defer server.Close()
 
-	configurer := func() (whclient.Config, error) {
-		return whclient.Config{
+	configurer := func() (client.Config, error) {
+		return client.Config{
 			ID:        "workerid",
 			Token:     workeridjwt,
 			ProxyAddr: "ws://register.tcproxy.dev:" + getPort(server.URL),
 		}, nil
 	}
 
-	client, err := whclient.New(configurer)
+	client, err := client.New(configurer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wsproxy/util.go
+++ b/wsproxy/util.go
@@ -1,4 +1,4 @@
-package whproxy
+package wsproxy
 
 import (
 	"io"

--- a/wsproxy/wsproxy.go
+++ b/wsproxy/wsproxy.go
@@ -1,4 +1,4 @@
-package whproxy
+package wsproxy
 
 import (
 	"io"
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/taskcluster/webhooktunnel/util"
-	"github.com/taskcluster/webhooktunnel/wsmux"
+	"github.com/taskcluster/websocktunnel/util"
+	"github.com/taskcluster/websocktunnel/wsmux"
 )
 
 func (p *proxy) websocketProxy(w http.ResponseWriter, r *http.Request, session *wsmux.Session, tunnelID string) error {


### PR DESCRIPTION
More specifically:
 * webhooktunnel -> websocktunnel
 * whproxy -> wsproxy
 * whclient -> client (package name), wst-client (command name)