### PR TITLE
Make websocktunnel a binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 #wsmux
-wsmux/test_log
-websocktunnel
+./websocktunnel
 main
 certs/
 cmd/client/client

--- a/cmd/wst-client/main.go
+++ b/cmd/wst-client/main.go
@@ -1,3 +1,10 @@
+// +build !go1.7
+// +build !go1.8
+// +build !go1.9
+// +build go1.10
+// +build !go1.11
+// +build !go1.12
+
 package main
 
 import (


### PR DESCRIPTION
I thought of making some of the websocktunnel logging `.Debug`, but the local Logger interface only allows .Printf, and that makes me think that it needs to be generic enough to work without Logrus -- maybe in generic-worker?