### PR TITLE
Bug 1517339 - include a port in the client URL

### DIFF
--- a/cmd/websocktunnel/main.go
+++ b/cmd/websocktunnel/main.go
@@ -1,10 +1,3 @@
-// +build !go1.7
-// +build !go1.8
-// +build !go1.9
-// +build go1.10
-// +build !go1.11
-// +build !go1.12
-
 package main
 
 import (

--- a/cmd/websocktunnel/main.go
+++ b/cmd/websocktunnel/main.go
@@ -6,8 +6,9 @@ import (
 	"log/syslog"
 	"net/http"
 	"os"
+	"strconv"
 
-	"github.com/docopt/docopt-go"
+	docopt "github.com/docopt/docopt-go"
 	"github.com/gorilla/websocket"
 	mozlog "github.com/mozilla-services/go-mozlogrus"
 	log "github.com/sirupsen/logrus"
@@ -84,6 +85,10 @@ func main() {
 			port = "80"
 		}
 	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		panic(err)
+	}
 
 	upgrader := websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
@@ -98,6 +103,7 @@ func main() {
 		JWTSecretA: []byte(signingSecretA),
 		JWTSecretB: []byte(signingSecretB),
 		Domain:     hostname,
+		Port:       portNum,
 		TLS:        useTLS,
 	})
 

--- a/cmd/wst-client/main.go
+++ b/cmd/wst-client/main.go
@@ -1,10 +1,3 @@
-// +build !go1.7
-// +build !go1.8
-// +build !go1.9
-// +build go1.10
-// +build !go1.11
-// +build !go1.12
-
 package main
 
 import (

--- a/wsproxy/proxy_test.go
+++ b/wsproxy/proxy_test.go
@@ -3,6 +3,7 @@ package wsproxy
 import (
 	"bytes"
 	"fmt"
+
 	// "crypto/tls"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 	"github.com/taskcluster/websocktunnel/client"
@@ -64,6 +65,8 @@ func TestProxyRegister(t *testing.T) {
 		Logger:     genLogger(),
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -106,6 +109,8 @@ func TestProxyRegisterInvalidClientId(t *testing.T) {
 		Logger:     genLogger(),
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -139,6 +144,8 @@ func TestProxyRequest(t *testing.T) {
 		Logger:     genLogger(),
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -236,6 +243,8 @@ func TestProxyURIRewrite(t *testing.T) {
 		Logger:     genLogger(),
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -295,6 +304,8 @@ func TestProxyWebsocket(t *testing.T) {
 		Upgrader:   upgrader,
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -381,6 +392,8 @@ func TestWebsocketProxyControl(t *testing.T) {
 		Logger:     genLogger(),
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 	proxy, err := New(proxyConfig)
 	if err != nil {
@@ -525,6 +538,8 @@ func TestWebSocketClosure(t *testing.T) {
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
 		Logger:     proxyLogger,
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -627,6 +642,8 @@ func TestProxySessionRemoved(t *testing.T) {
 		Upgrader:   upgrader,
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := newProxy(proxyConfig)
@@ -669,6 +686,8 @@ func TestProxyAuth(t *testing.T) {
 		Upgrader:   upgrader,
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -703,6 +722,8 @@ func TestConcurrentConnections(t *testing.T) {
 		Upgrader:   upgrader,
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 	proxy, err := New(proxyConfig)
 	if err != nil {
@@ -767,6 +788,8 @@ func TestProxySecrets(t *testing.T) {
 		Upgrader:   upgrader,
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -836,6 +859,8 @@ func TestResponseStream(t *testing.T) {
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
 		Logger:     proxyLogger,
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -921,6 +946,8 @@ func TestWebSocketStreamClient(t *testing.T) {
 		Upgrader:   upgrader,
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
+		Domain:     "localhost",
+		Port:       80,
 	}
 
 	proxy, err := New(proxyConfig)
@@ -998,6 +1025,7 @@ func TestGetRequestWithClient(t *testing.T) {
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
 		Domain:     "localhost",
+		Port:       80,
 		Logger:     genLogger(),
 	}
 	proxy, err := New(proxyConfig)
@@ -1087,6 +1115,7 @@ func TestClientURL(t *testing.T) {
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
 		Domain:     "localhost",
+		Port:       80,
 		Logger:     genLogger(),
 	}
 	proxy, err := New(proxyConfig)
@@ -1118,6 +1147,7 @@ func TestProxyWebSocketPath(t *testing.T) {
 		JWTSecretA: []byte("test-secret"),
 		JWTSecretB: []byte("another-secret"),
 		Domain:     "localhost",
+		Port:       80,
 		Logger:     genLogger(),
 	}
 	proxy, err := New(proxyConfig)


### PR DESCRIPTION
This also removes the go-version build restrictions, as they seem to cause things not to build on go1.10.3.