### PR TITLE
Consistently remove the /<tunnelId> portion of the path

### DIFF
--- a/wsproxy/proxy.go
+++ b/wsproxy/proxy.go
@@ -268,7 +268,7 @@ func (p *proxy) serveRequest(w http.ResponseWriter, r *http.Request, id string, 
 
 	// check for a websocket request
 	if websocket.IsWebSocketUpgrade(r) {
-		_ = p.websocketProxy(w, r, session, id)
+		_ = p.websocketProxy(w, r, session, id, path)
 		return
 	}
 

--- a/wsproxy/proxy_test.go
+++ b/wsproxy/proxy_test.go
@@ -318,6 +318,10 @@ func TestProxyWebsocket(t *testing.T) {
 	defer server.Close()
 
 	clientHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/abc" {
+			t.Fatalf("Got incorrect path %s", r.URL.Path)
+		}
+
 		if !websocket.IsWebSocketUpgrade(r) {
 			http.NotFound(w, r)
 		}
@@ -356,7 +360,7 @@ func TestProxyWebsocket(t *testing.T) {
 	}()
 
 	// create websocket connection
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL+"/wsworker/", nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL+"/wsworker/abc", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1171,7 +1175,7 @@ func TestProxyWebSocketPath(t *testing.T) {
 		if !websocket.IsWebSocketUpgrade(r) {
 			panic("request should be a websocket upgrade")
 		}
-		if r.URL.RequestURI() != "/myclient"+reqURI {
+		if r.URL.RequestURI() != reqURI {
 			panic(fmt.Sprintf("invalid request uri propogated: %s", r.URL.RequestURI()))
 		}
 		conn, err := upgrader.Upgrade(w, r, nil)

--- a/wsproxy/wsproxy.go
+++ b/wsproxy/wsproxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/taskcluster/websocktunnel/wsmux"
 )
 
-func (p *proxy) websocketProxy(w http.ResponseWriter, r *http.Request, session *wsmux.Session, tunnelID string) error {
+func (p *proxy) websocketProxy(w http.ResponseWriter, r *http.Request, session *wsmux.Session, tunnelID string, path string) error {
 	// at this point, we are sure that r is a http websocket upgrade request
 	// connClosure returns the wsmux stream to Dial
 	p.logf(tunnelID, r.RemoteAddr, "creating WS bridge: path=%s", r.URL.RequestURI())
@@ -46,7 +46,7 @@ func (p *proxy) websocketProxy(w http.ResponseWriter, r *http.Request, session *
 		reqHeader[k] = v
 	}
 
-	uri := "ws://" + r.Host + r.URL.RequestURI()
+	uri := "ws://" + r.Host + path
 	p.logf(tunnelID, r.RemoteAddr, "dialing ws on stream, url: %s", uri)
 	tunnelConn, _, err := dialer.Dial(uri, reqHeader)
 	if err != nil {


### PR DESCRIPTION
@ckousik do you happen to remember if this difference was intentional, and if so, why?