### PR TITLE
Add dockerflow /__lbheartbeat__ endpoint

### DIFF
--- a/wsproxy/proxy.go
+++ b/wsproxy/proxy.go
@@ -77,6 +77,11 @@ func New(conf Config) (http.Handler, error) {
 func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.logf("", r.RemoteAddr, "Host=%s Path=%s", r.Host, r.URL.Path)
 
+	// Dockerflow
+	if r.URL.Path == "/__lbheartbeat__" {
+		return
+	}
+
 	// Client registration requests are a GET of path / with some headers set
 	if path, id := r.URL.Path, r.Header.Get("x-websocktunnel-id"); id != "" && path == "/" {
 		tokenString := util.ExtractJWT(r.Header.Get("Authorization"))


### PR DESCRIPTION
This adds support for the /__lbheartbeat__ endpoint defined
in https://github.com/mozilla-services/dockerflow

Here is a request demonstrating it working:

```
$ curl -v http://127.0.0.1:8080/__lbheartbeat__
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> GET /__lbheartbeat__ HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Fri, 11 Oct 2019 18:02:29 GMT
< Content-Length: 0
< 
* Connection #0 to host 127.0.0.1 left intact
```

Fixes #48.